### PR TITLE
Add $servlet_context variable to running rack application

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ In Depth
   your logging backend][slf4j-backend]. Log messages are written to
   `com.squareup.rack.RackLogger` and `com.squareup.rack.RackErrors`,
   respectively.
+- **ServletContext**: You can use the global variable `$servlet_context` to access
+  the current context.
 
 Support
 -------

--- a/core/src/main/java/com/squareup/rack/RackApplication.java
+++ b/core/src/main/java/com/squareup/rack/RackApplication.java
@@ -15,12 +15,21 @@
  */
 package com.squareup.rack;
 
+import javax.servlet.ServletContext;
+
 /**
  * A Rack application.
  *
  * @see <a href="http://rack.rubyforge.org/doc/SPEC.html">The Rack Specification</a>
  */
 public interface RackApplication {
+  /**
+   * Setup the environment once when the servlet started
+   *
+   * @param servletContext the ServletContext to set
+   */
+  void setup(ServletContext servletContext);
+
   /**
    * Processes a single HTTP request.
    *

--- a/core/src/main/java/com/squareup/rack/jruby/JRubyRackApplication.java
+++ b/core/src/main/java/com/squareup/rack/jruby/JRubyRackApplication.java
@@ -26,7 +26,10 @@ import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyHash;
 import org.jruby.internal.runtime.ThreadService;
+import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.builtin.IRubyObject;
+
+import javax.servlet.ServletContext;
 
 import static org.jruby.RubyHash.newHash;
 
@@ -52,6 +55,17 @@ public class JRubyRackApplication implements RackApplication {
     this.application = application;
     this.runtime = application.getRuntime();
     this.threadService = runtime.getThreadService();
+  }
+
+  /**
+   * Sets the $servlet_context global variable in the applications runtime
+   *
+   * @param servletContext the ServletContext to set
+   */
+  public void setup(ServletContext servletContext) {
+    final Ruby runtime = application.getRuntime();
+    IRubyObject rubyContext = JavaUtil.convertJavaToRuby(runtime, servletContext);
+    runtime.getGlobalVariables().set("$servlet_context", rubyContext);
   }
 
   /**

--- a/core/src/main/java/com/squareup/rack/servlet/RackServlet.java
+++ b/core/src/main/java/com/squareup/rack/servlet/RackServlet.java
@@ -61,6 +61,10 @@ public class RackServlet extends HttpServlet {
     this.rackResponsePropagator = rackResponsePropagator;
   }
 
+  @Override public void init() throws ServletException {
+    this.rackApplication.setup(getServletContext());
+  }
+
   @Override protected void service(HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
     RackEnvironment rackEnvironment = rackEnvironmentBuilder.build(request);

--- a/integration/src/test/java/com/squareup/rack/integration/GlobalVariablesTest.java
+++ b/integration/src/test/java/com/squareup/rack/integration/GlobalVariablesTest.java
@@ -1,0 +1,61 @@
+package com.squareup.rack.integration;
+
+import com.squareup.rack.jruby.JRubyRackApplication;
+import com.squareup.rack.servlet.RackServlet;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.jruby.embed.ScriptingContainer;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.jruby.embed.PathType.CLASSPATH;
+import static org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY;
+
+/**
+ * Created by andi on 25/03/14.
+ */
+public class GlobalVariablesTest {
+
+  private HttpClient client;
+  private HttpHost localhost;
+  private ExampleServer server;
+
+  @Before
+  public void setUp() throws Exception {
+    // Silence logging.
+    System.setProperty(DEFAULT_LOG_LEVEL_KEY, "WARN");
+
+    // Build the Rack servlet.
+    ScriptingContainer ruby = new ScriptingContainer();
+    IRubyObject application = ruby.parse(CLASSPATH, "application.rb").run();
+    RackServlet servlet = new RackServlet(new JRubyRackApplication(application));
+
+    server = new ExampleServer(servlet, "/*");
+    server.start();
+    client = new DefaultHttpClient();
+    localhost = new HttpHost("localhost", server.getPort());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    server.stop();
+  }
+
+  @Test
+  public void setsGlobalVariables() throws IOException {
+    HttpResponse response = get("/global_vars");
+    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+  }
+
+  private HttpResponse get(String path) throws IOException {
+    return client.execute(localhost, new HttpGet(path));
+  }
+}

--- a/integration/src/test/resources/application.rb
+++ b/integration/src/test/resources/application.rb
@@ -1,6 +1,14 @@
 require 'sinatra/base'
 
 class Application < Sinatra::Base
+  get '/global_vars' do
+    if $servlet_context
+      [200, '']
+    else
+      [404, '']
+    end
+  end
+
   get '/set-multiple-cookies' do
     response.set_cookie :foo, 'bar'
     response.set_cookie :bar, 'foo'


### PR DESCRIPTION
With jruby-rack you can access the current ServletContext via $servlet_context. This commit replicates this feature. Test is included in integration tests.
