### PR TITLE
RackEnvironmentBuilder: handle header punctuation differences.

### DIFF
--- a/core/src/test/java/com/squareup/rack/servlet/RackEnvironmentBuilderTest.java
+++ b/core/src/test/java/com/squareup/rack/servlet/RackEnvironmentBuilderTest.java
@@ -106,6 +106,22 @@ public class RackEnvironmentBuilderTest {
     assertThat(environment()).doesNotContainKey("HTTP_CONTENT_TYPE");
   }
 
+  @Test public void httpHeadersXForwardedForMultiple() {
+    request.header("X-Forwarded-For", "192.168.0.1");
+    request.header("X-Forwarded-For", "10.0.1.1");
+    assertThat(environment()).contains(entry("HTTP_X_FORWARDED_FOR", "192.168.0.1,10.0.1.1"));
+  }
+
+  @Test public void httpHeadersXForwardedForMultiplePunctuationDifferences() {
+    // There seems to be mixed consensus on the internet as to what to do in this case. Underscores
+    // are perfectly valid in HTTP header names, but many webservers discard such headers so as to
+    // avoid collision with CGI environment variables. (See nginx's underscores_in_headers setting.)
+    // We choose to honor them, folding their values in with their dashed brethren.
+    request.header("X-Forwarded-For", "192.168.0.1");
+    request.header("X-Forwarded_For", "10.0.1.1");
+    assertThat(environment()).contains(entry("HTTP_X_FORWARDED_FOR", "192.168.0.1,10.0.1.1"));
+  }
+
   @Test public void rackVersion() {
     assertThat(environment()).contains(entry("rack.version", ImmutableList.of(1, 2)));
   }


### PR DESCRIPTION
Something upstream of us sent `X-Forwarded-For` headers that both mapped to `HTTP_X_FORWARDED_FOR`, breaking `ImmutableMap.Builder`'s contract. Since it looks like (Jetty's `HttpFields` and) the servlet spec claim support for case-insensitive header semantics, the dash/underscore difference is all else I can imagine.