### PR TITLE
Lazily allocate the rack.input buffer.

### DIFF
--- a/core/src/main/java/com/squareup/rack/io/TempfileBufferedInputStream.java
+++ b/core/src/main/java/com/squareup/rack/io/TempfileBufferedInputStream.java
@@ -149,7 +149,7 @@ public class TempfileBufferedInputStream extends InputStream {
 
     public MemoryBuffer(int threshold) {
       this.threshold = threshold;
-      this.cacheOutputStream = new ByteArrayBuffer(threshold);
+      this.cacheOutputStream = new ByteArrayBuffer();
     }
 
     public void replay(byte[] bytes, int offset, int bytesToTransfer) {


### PR DESCRIPTION
Previously, we allocated 1MB for every request! Boo.