### PR TITLE
Reading from slow streams

### DIFF
--- a/core/src/main/java/com/squareup/rack/RackInput.java
+++ b/core/src/main/java/com/squareup/rack/RackInput.java
@@ -152,7 +152,11 @@ public class RackInput implements Closeable {
 
     int bytesStillNeeded = length - buffer.getLength();
     if (bytesStillNeeded > 0) {
-      fillBuffer(bytesStillNeeded);
+      int bytesRead = fillBuffer(bytesStillNeeded);
+      while (bytesRead != -1 && bytesStillNeeded > 0) {
+        bytesStillNeeded -= bytesRead;
+        bytesRead = fillBuffer(bytesStillNeeded);
+      }
     }
 
     return consumeBytesFromBuffer(length);

--- a/core/src/test/java/com/squareup/rack/RackInputTest.java
+++ b/core/src/test/java/com/squareup/rack/RackInputTest.java
@@ -1,6 +1,7 @@
 package com.squareup.rack;
 
 import java.io.ByteArrayInputStream;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -13,10 +14,12 @@ public class RackInputTest {
 
   private RackInput empty;
   private RackInput full;
+  private RackInput fullSlow;
 
   @Before public void setUp() throws Exception {
     empty = rackInputFor(EMPTY_BYTES);
     full = rackInputFor(BYTES);
+    fullSlow = slowRackInputFor(BYTES);
   }
 
   @Test public void getsAtEof() throws Exception {
@@ -70,6 +73,15 @@ public class RackInputTest {
     assertThat(full.read(4)).isEqualTo(copyOfRange(BYTES, 4, 8));
   }
 
+  @Test public void readFromSlowStreamWithLength() throws Exception {
+    assertThat(fullSlow.read(4)).isEqualTo(copyOfRange(BYTES, 0, 4));
+  }
+
+  @Test public void readFromSlowStreamWithLengthAgain() throws Exception {
+    fullSlow.read(4);
+    assertThat(fullSlow.read(4)).isEqualTo(copyOfRange(BYTES, 4, 8));
+  }
+
   @Test public void readWithLengthTooLong() throws Exception {
     assertThat(full.read(BYTES.length + 1)).isEqualTo(BYTES);
   }
@@ -111,5 +123,9 @@ public class RackInputTest {
 
   private RackInput rackInputFor(byte[] bytes) throws Exception {
     return new RackInput(new ByteArrayInputStream(bytes));
+  }
+
+  private RackInput slowRackInputFor(byte[] bytes) throws Exception {
+    return new RackInput(new SlowByteArrayInputStream(bytes));
   }
 }

--- a/core/src/test/java/com/squareup/rack/SlowByteArrayInputStream.java
+++ b/core/src/test/java/com/squareup/rack/SlowByteArrayInputStream.java
@@ -1,0 +1,28 @@
+package com.squareup.rack;
+
+import java.io.ByteArrayInputStream;
+
+class SlowByteArrayInputStream extends ByteArrayInputStream {
+
+    public SlowByteArrayInputStream(byte[] buf) {
+        super(buf);
+    }
+
+    @Override
+    public final int read(byte[] b, int off, int len) {
+        if (pos >= count) {
+            return -1;
+        }
+        if ((pos + len) > count) {
+            len = (count - pos);
+        }
+        if (len <= 0) {
+            return 0;
+        }
+        // Ensure we only read two bytes per read
+        len = Math.min(len, 2);
+        System.arraycopy(buf, pos, b, off, len);
+        pos += len;
+        return len;
+    }
+}


### PR DESCRIPTION
Symptom: We were seeing very strange issues where the body of requests were being partially consumed. Here's an example that we captured from one of our servers with tcp logging (example was edited for privacy):

```
POST <route> HTTP/1.1
Host: <hostname>:<port>
Cookie: JSESSIONID=XXX
Content-Type: application/json;charset=UTF-8
HEADER-LENGTH-TEST: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Content-Length: 222

{"titl
HTTP/1.1 400 Bad Request
Date: Mon, 06 Mar 2017 20:02:47 GMT
Content-Type: text/html;charset=utf-8
Content-Length: 0

13     FIN-WAIT-1     <ip>:<port> > <ip>:bctp
13     FIN-WAIT-2     <ip>:<port> > <ip>:bctp
e":"Units","units":[...],"id":"AR","start_date":"2012-03-06T18:53:07.212Z","end_date":"2017-03-06T18:53:07.213Z"}
13     RESET          <ip>:<port> > <ip>:bctp
```

Notice how the body was chopped in half with the server only picking up the first 6 characters. Oddly enough at the 1024 boundary. The content should look like this to the server:

```
{"title":"Units","units":[...],"id":"AR","start_date":"2012-03-06T18:53:07.212Z","end_date":"2017-03-06T18:53:07.213Z"}
```

but only `{"titl` was being picked up causing issues. Through debugging and help from coworkers we noticed that in certain cases, i.e. slow connections, VPN, etc the stream still contained data that the rack-servlet wasn't waiting for. The easiest way to replicate this issue in the tests was to create a custom input stream that only read two bytes at a time.

If you need more clarification or I need to clean anything up please let me know.